### PR TITLE
Add history page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import Index from "./pages/Index";
+import History from "./pages/History";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -19,6 +20,7 @@ const App = () => (
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />
+            <Route path="/history" element={<History />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 import { Terminal, Shield, Zap, Sun, Moon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useTheme } from '@/contexts/ThemeContext';
+import { Link } from 'react-router-dom';
 
 export const Header = () => {
   const { theme, toggleTheme } = useTheme();
@@ -23,6 +24,14 @@ export const Header = () => {
                 AI SECURITY TESTING SUITE
               </p>
             </div>
+            <nav className="ml-8 space-x-4 hidden md:block">
+              <Link to="/" className="text-sm text-gray-300 hover:text-red-400">
+                Dashboard
+              </Link>
+              <Link to="/history" className="text-sm text-gray-300 hover:text-red-400">
+                History
+              </Link>
+            </nav>
           </div>
           
           <div className="flex items-center space-x-4">

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { Header } from '@/components/Header';
+import { getResults, TestRunResult } from '@/utils/redpromptApi';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+
+const History = () => {
+  const [runs, setRuns] = useState<TestRunResult[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await getResults();
+        setRuns(res.results);
+      } catch (err: any) {
+        setError(err.message || 'Failed to load history');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-black text-green-400 font-mono">
+      <div className="bg-gradient-to-b from-red-950/20 to-black min-h-screen">
+        <Header />
+        <div className="container mx-auto px-6 py-8 space-y-6">
+          <h2 className="text-xl font-semibold text-red-400">TEST RUN HISTORY</h2>
+          {loading ? (
+            <p className="text-gray-400">Loading...</p>
+          ) : error ? (
+            <p className="text-red-400">{error}</p>
+          ) : runs.length === 0 ? (
+            <p className="text-gray-400">No previous runs found.</p>
+          ) : (
+            <Table className="bg-gray-900/50 border border-red-500/30 rounded-lg">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Target URL</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Total Prompts</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {runs.map((run) => (
+                  <TableRow key={run.test_run_id}>
+                    <TableCell className="font-mono text-xs">
+                      {run.test_run_id}
+                    </TableCell>
+                    <TableCell>{run.target_url}</TableCell>
+                    <TableCell>{run.status}</TableCell>
+                    <TableCell>
+                      {new Date(run.timestamp).toLocaleString()}
+                    </TableCell>
+                    <TableCell>{run.total_prompts}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default History;


### PR DESCRIPTION
## Summary
- add History page to display past test runs
- link to history in header navigation
- register history route in app

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867d8e9bb08833189f99f07a385984c